### PR TITLE
ci: workflows on queues, go version from go.mod

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,9 +1,9 @@
 name: golangci-lint
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  merge_group:
 
 jobs:
 
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     funlen:
       lines: 100
     revive:
+      enable-default-rules: true
       rules:
         - name: package-comments
           disabled: true

--- a/cmd/gateway/commands/app.go
+++ b/cmd/gateway/commands/app.go
@@ -8,15 +8,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+// App is the main application struct holding configuration state.
 type App struct {
 	cfgFile string
 	v       *viper.Viper
 }
 
+// NewApp creates a new App instance.
 func NewApp() *App {
 	return &App{v: viper.New()}
 }
 
+// Execute runs the root command.
 func Execute() {
 	app := NewApp()
 	if err := app.newRootCmd().Execute(); err != nil {
@@ -32,7 +35,7 @@ func (a *App) newRootCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&a.cfgFile, "config", "", "config file (default is $HOME/.shinzo-network-gateway.yaml)")
-	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
 		return a.initConfig()
 	}
 

--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -25,7 +25,7 @@ func (a *App) newStartCmd() *cobra.Command {
 	}
 }
 
-func (a *App) startGateway(cmd *cobra.Command, args []string) error {
+func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 	logger, err := zap.NewDevelopment()
 	defer func() {
 		_ = logger.Sync()


### PR DESCRIPTION
Few improvements for workflows:
1. Run them on build queues (otherwise it's impossible to merge from queue :sweat_smile:)
2. Use go version from `go.mod` file, for consistency.
3. Enable default revive rules.