### PR TITLE
ci: add codecov setup to go-test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -25,5 +25,9 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test ./...
+      run: go test -coverprofile=coverage.txt ./...
 
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I configured repository-scoped `CODECOV_TOKEN` secret.

Resolves #16.