### PR TITLE
feat: require limit and order in queries

### DIFF
--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -20,6 +20,9 @@ import (
 
 const shutdownTimeout = 30 * time.Second
 
+// TODO(tzdybal): add configuration option.
+const maxLimit = 100_000
+
 func (a *App) newStartCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -70,8 +73,8 @@ func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 		logger,
 	)
 
-	// TODO(tzdybal): setup validators
-	handler := endpoint.NewHandler(nil, &endpoint.DefaultCollectionExtractor{}, rtr, logger)
+	validators := []endpoint.Validator{endpoint.NewLimitValidator(maxLimit)}
+	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, logger)
 	endp, err := endpoint.New(a.v.GetString(flagListen), handler, logger)
 	if err != nil {
 		return fmt.Errorf("error while creating endpoint: %w", err)

--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -73,7 +73,7 @@ func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 		logger,
 	)
 
-	validators := []endpoint.Validator{endpoint.NewLimitValidator(maxLimit)}
+	validators := []endpoint.Validator{endpoint.NewLimitValidator(maxLimit), &endpoint.OrderValidator{}}
 	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, logger)
 	endp, err := endpoint.New(a.v.GetString(flagListen), handler, logger)
 	if err != nil {

--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -70,7 +70,8 @@ func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 		logger,
 	)
 
-	handler := endpoint.NewHandler(&endpoint.DefaultCollectionExtractor{}, rtr, logger)
+	// TODO(tzdybal): setup validators
+	handler := endpoint.NewHandler(nil, &endpoint.DefaultCollectionExtractor{}, rtr, logger)
 	endp, err := endpoint.New(a.v.GetString(flagListen), handler, logger)
 	if err != nil {
 		return fmt.Errorf("error while creating endpoint: %w", err)

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -40,6 +40,10 @@ var ErrValidation = errors.New("validation failed")
 // ErrMissingLimit is returned when a root field is missing a required limit argument.
 var ErrMissingLimit = errors.New("limit not specified")
 
+// ErrUnsupportedSelection is returned when a root selection is not a plain field
+// (a fragment spread or inline fragment).
+var ErrUnsupportedSelection = errors.New("unsupported root selection")
+
 // ErrInvalidLimit is returned when a limit argument is present but its value
 // cannot be statically verified (non-integer literal or a variable) or is not positive.
 var ErrInvalidLimit = errors.New("invalid limit")

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -40,16 +40,13 @@ var ErrValidation = errors.New("validation failed")
 // ErrMissingLimit is returned when a root field is missing a required limit argument.
 var ErrMissingLimit = errors.New("limit not specified")
 
+// ErrInvalidLimit is returned when a limit argument is present but invalid:
+// not a positive 32-bit integer literal, duplicated, or exceeding the maximum.
+var ErrInvalidLimit = errors.New("invalid limit")
+
 // ErrUnsupportedSelection is returned when a root selection is not a plain field
 // (a fragment spread or inline fragment).
 var ErrUnsupportedSelection = errors.New("unsupported root selection")
-
-// ErrInvalidLimit is returned when a limit argument is present but its value
-// cannot be statically verified (non-integer literal or a variable) or is not positive.
-var ErrInvalidLimit = errors.New("invalid limit")
-
-// ErrLimitTooLarge is returned when a limit value exceeds the configured maximum.
-var ErrLimitTooLarge = errors.New("limit exceeds maximum")
 
 // ErrHostHTTP is returned when an upstream host responds with a non-2xx status.
 var ErrHostHTTP = errors.New("host HTTP error")

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -44,6 +44,14 @@ var ErrMissingLimit = errors.New("limit not specified")
 // not a positive 32-bit integer literal, duplicated, or exceeding the maximum.
 var ErrInvalidLimit = errors.New("invalid limit")
 
+// ErrMissingOrder is returned when a root field is missing a required order argument.
+var ErrMissingOrder = errors.New("order not specified")
+
+// ErrInvalidOrder is returned when an order argument is present but invalid:
+// not a DefraDB-compatible object/list of single-field {field: ASC|DESC}
+// conditions, duplicated, or carrying an unknown direction.
+var ErrInvalidOrder = errors.New("invalid order")
+
 // ErrUnsupportedSelection is returned when a root selection is not a plain field
 // (a fragment spread or inline fragment).
 var ErrUnsupportedSelection = errors.New("unsupported root selection")

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -34,6 +34,19 @@ var ErrEmptyQuery = errors.New("empty GraphQL query")
 // ErrParse is returned if GraphQL query cannot be parsed.
 var ErrParse = errors.New("GraphQL parse error")
 
+// ErrValidation is returned when a GraphQL query fails validation.
+var ErrValidation = errors.New("validation failed")
+
+// ErrMissingLimit is returned when a root field is missing a required limit argument.
+var ErrMissingLimit = errors.New("limit not specified")
+
+// ErrInvalidLimit is returned when a limit argument is present but its value
+// cannot be statically verified (non-integer literal or a variable) or is not positive.
+var ErrInvalidLimit = errors.New("invalid limit")
+
+// ErrLimitTooLarge is returned when a limit value exceeds the configured maximum.
+var ErrLimitTooLarge = errors.New("limit exceeds maximum")
+
 // ErrHostHTTP is returned when an upstream host responds with a non-2xx status.
 var ErrHostHTTP = errors.New("host HTTP error")
 

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -31,6 +31,9 @@ type gqlLocation struct {
 // ErrEmptyQuery is returned if GraphQL query is empty.
 var ErrEmptyQuery = errors.New("empty GraphQL query")
 
+// ErrParse is returned if GraphQL query cannot be parsed.
+var ErrParse = errors.New("GraphQL parse error")
+
 // ErrHostHTTP is returned when an upstream host responds with a non-2xx status.
 var ErrHostHTTP = errors.New("host HTTP error")
 

--- a/endpoint/extractor.go
+++ b/endpoint/extractor.go
@@ -2,27 +2,18 @@ package endpoint
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/vektah/gqlparser/v2/parser"
 )
 
 // CollectionsExtractor defines interface for extracting root collections from GraphQL queries.
 type CollectionsExtractor interface {
-	ExtractCollections(graphql string) ([]string, error)
+	ExtractCollections(query *ast.QueryDocument) ([]string, error)
 }
 
 // DefaultCollectionExtractor provides default implementation for root collections extraction.
 type DefaultCollectionExtractor struct{}
 
 // ExtractCollections parses GraphQL into AST and then traverse to get the root collections.
-func (e *DefaultCollectionExtractor) ExtractCollections(graphql string) ([]string, error) {
-	if len(graphql) == 0 {
-		return nil, ErrEmptyQuery
-	}
-	query, err := parser.ParseQuery(&ast.Source{Input: graphql})
-	if err != nil {
-		return nil, err
-	}
-
+func (e *DefaultCollectionExtractor) ExtractCollections(query *ast.QueryDocument) ([]string, error) {
 	rootCollections := make([]string, 0, 1)
 	for _, op := range query.Operations {
 		for _, sel := range op.SelectionSet {

--- a/endpoint/extractor.go
+++ b/endpoint/extractor.go
@@ -12,15 +12,15 @@ type CollectionsExtractor interface {
 // DefaultCollectionExtractor provides default implementation for root collections extraction.
 type DefaultCollectionExtractor struct{}
 
-// ExtractCollections parses GraphQL into AST and then traverse to get the root collections.
+// ExtractCollections walks the parsed query's root field selections to get the root collections.
 func (e *DefaultCollectionExtractor) ExtractCollections(query *ast.QueryDocument) ([]string, error) {
-	rootCollections := make([]string, 0, 1)
-	for _, op := range query.Operations {
-		for _, sel := range op.SelectionSet {
-			if field, ok := sel.(*ast.Field); ok {
-				rootCollections = append(rootCollections, field.Name)
-			}
-		}
+	fields, err := rootFields(query)
+	if err != nil {
+		return nil, err
+	}
+	rootCollections := make([]string, 0, len(fields))
+	for _, field := range fields {
+		rootCollections = append(rootCollections, field.Name)
 	}
 	return rootCollections, nil
 }

--- a/endpoint/extractor_test.go
+++ b/endpoint/extractor_test.go
@@ -132,18 +132,17 @@ func TestDefaultCollectionsExtractor(t *testing.T) {
 			t.Parallel()
 
 			extr := &DefaultCollectionExtractor{}
-			ast, parseErr := parseQuery(c.query)
-			if c.err && parseErr != nil {
-				return
-			}
-			collections, err := extr.ExtractCollections(ast)
+			query, err := parseQuery(c.query)
 
 			if c.err {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.ElementsMatch(t, collections, c.expected)
+				return
 			}
+			require.NoError(t, err)
+
+			collections, err := extr.ExtractCollections(query)
+			require.NoError(t, err)
+			require.ElementsMatch(t, collections, c.expected)
 		})
 	}
 }

--- a/endpoint/extractor_test.go
+++ b/endpoint/extractor_test.go
@@ -139,7 +139,7 @@ func TestDefaultCollectionsExtractor(t *testing.T) {
 			collections, err := extr.ExtractCollections(ast)
 
 			if c.err {
-				require.True(t, parseErr != nil || err != nil)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				require.ElementsMatch(t, collections, c.expected)

--- a/endpoint/extractor_test.go
+++ b/endpoint/extractor_test.go
@@ -125,6 +125,17 @@ func TestDefaultCollectionsExtractor(t *testing.T) {
 			}`,
 			expected: []string{"hero"},
 		},
+		{
+			name: "root fragment spread is rejected",
+			query: `{ ...Roots }
+			fragment Roots on Query { hero { name } }`,
+			err: true,
+		},
+		{
+			name:  "root inline fragment is rejected",
+			query: `{ ... on Query { hero { name } } }`,
+			err:   true,
+		},
 	}
 
 	for _, c := range cases {
@@ -134,13 +145,15 @@ func TestDefaultCollectionsExtractor(t *testing.T) {
 			extr := &DefaultCollectionExtractor{}
 			query, err := parseQuery(c.query)
 
+			var collections []string
+			if err == nil {
+				collections, err = extr.ExtractCollections(query)
+			}
+
 			if c.err {
 				require.Error(t, err)
 				return
 			}
-			require.NoError(t, err)
-
-			collections, err := extr.ExtractCollections(query)
 			require.NoError(t, err)
 			require.ElementsMatch(t, collections, c.expected)
 		})

--- a/endpoint/extractor_test.go
+++ b/endpoint/extractor_test.go
@@ -132,10 +132,14 @@ func TestDefaultCollectionsExtractor(t *testing.T) {
 			t.Parallel()
 
 			extr := &DefaultCollectionExtractor{}
-			collections, err := extr.ExtractCollections(c.query)
+			ast, parseErr := parseQuery(c.query)
+			if c.err && parseErr != nil {
+				return
+			}
+			collections, err := extr.ExtractCollections(ast)
 
 			if c.err {
-				require.Error(t, err)
+				require.True(t, parseErr != nil || err != nil)
 			} else {
 				require.NoError(t, err)
 				require.ElementsMatch(t, collections, c.expected)

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -113,8 +113,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	validationReq := &ValidationRequest{Query: query, Header: r.Header}
 	for _, v := range h.validators {
-		if err := v.Validate(&ValidationRequest{Query: query, Header: r.Header}); err != nil {
+		if err := v.Validate(validationReq); err != nil {
 			h.writeError(w, requestErrorStatus(contentType), fmt.Errorf("%w: %w", ErrValidation, err).Error(), contentType)
 			return
 		}

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -27,10 +27,11 @@ type HostsSelector interface {
 
 // Handler is a HTTP handler for "POST /graphql" endpoint.
 type Handler struct {
-	extractor CollectionsExtractor
-	selector  HostsSelector
-	client    *http.Client
-	logger    *zap.Logger
+	validators []Validator
+	extractor  CollectionsExtractor
+	selector   HostsSelector
+	client     *http.Client
+	logger     *zap.Logger
 }
 
 var _ http.Handler = &Handler{}
@@ -59,17 +60,18 @@ type hostResponse struct {
 }
 
 // NewHandler creates new Handler instance.
-func NewHandler(extractor CollectionsExtractor, selector HostsSelector, logger *zap.Logger) *Handler {
+func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, logger *zap.Logger) *Handler {
 	transport := &http.Transport{
 		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 
 	return &Handler{
-		extractor: extractor,
-		selector:  selector,
-		client:    &http.Client{Transport: transport},
-		logger:    logger.Named("handler"),
+		validators: validators,
+		extractor:  extractor,
+		selector:   selector,
+		client:     &http.Client{Transport: transport},
+		logger:     logger.Named("handler"),
 	}
 }
 
@@ -109,6 +111,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.writeError(w, requestErrorStatus(contentType), err.Error(), contentType)
 		return
+	}
+
+	for _, v := range h.validators {
+		if err := v.Validate(&ValidationRequest{Query: ast, Header: r.Header}); err != nil {
+			h.writeError(w, requestErrorStatus(contentType), fmt.Errorf("%w: %w", ErrValidation, err).Error(), contentType)
+			return
+		}
 	}
 
 	collections, err := h.extractor.ExtractCollections(ast)

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -107,20 +107,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ast, err := parseQuery(gqlReq.Query)
+	query, err := parseQuery(gqlReq.Query)
 	if err != nil {
 		h.writeError(w, requestErrorStatus(contentType), err.Error(), contentType)
 		return
 	}
 
 	for _, v := range h.validators {
-		if err := v.Validate(&ValidationRequest{Query: ast, Header: r.Header}); err != nil {
+		if err := v.Validate(&ValidationRequest{Query: query, Header: r.Header}); err != nil {
 			h.writeError(w, requestErrorStatus(contentType), fmt.Errorf("%w: %w", ErrValidation, err).Error(), contentType)
 			return
 		}
 	}
 
-	collections, err := h.extractor.ExtractCollections(ast)
+	collections, err := h.extractor.ExtractCollections(query)
 	if err != nil {
 		h.writeError(w, requestErrorStatus(contentType), err.Error(), contentType)
 		return

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -105,7 +105,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	collections, err := h.extractor.ExtractCollections(gqlReq.Query)
+	ast, err := parseQuery(gqlReq.Query)
+	if err != nil {
+		h.writeError(w, requestErrorStatus(contentType), err.Error(), contentType)
+		return
+	}
+
+	collections, err := h.extractor.ExtractCollections(ast)
 	if err != nil {
 		h.writeError(w, requestErrorStatus(contentType), err.Error(), contentType)
 		return

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -42,6 +42,12 @@ func (m *mockSelector) SelectHosts(ctx context.Context, collections []string) ([
 	return args.Get(0).([]host.Host), args.Error(1)
 }
 
+type failValidator struct{}
+
+func (*failValidator) Validate(req *ValidationRequest) error {
+	return errFail
+}
+
 func TestGetContentType(t *testing.T) {
 	t.Parallel()
 
@@ -227,6 +233,7 @@ func TestHandler(t *testing.T) {
 		body           string
 		accept         string
 		reqContentType string
+		validators     []Validator
 		setupExtractor func(*mockExtractor)
 		setupSelector  func(*mockSelector, []host.Host)
 		wantStatus     int
@@ -265,10 +272,19 @@ func TestHandler(t *testing.T) {
 			wantBodyHas:    "unsupported Content-Type",
 		},
 		{
-			name:        "extractor error",
+			name:        "parser error",
 			body:        `{"query":"bad"}`,
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "parse error",
+		},
+		{
+			name: "extractor error",
+			body: `{"query":"{ hero { name } }"}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string(nil), errFail)
+			},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: errFail.Error(),
 		},
 		{
 			name: "selector error",
@@ -301,6 +317,47 @@ func TestHandler(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBodyHas: "parse error",
 		},
+		{
+			name:        "missing limit",
+			body:        `{"query":"{ hero { name } }"}`,
+			validators:  []Validator{&LimitValidator{limit: 100}},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: ErrMissingLimit.Error(),
+		},
+		{
+			name:        "invalid limit",
+			body:        `{"query":"{ hero(limit: -1) { name } }"}`,
+			validators:  []Validator{&LimitValidator{limit: 100}},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: ErrInvalidLimit.Error(),
+		},
+		{
+			name:        "limit exceeded",
+			body:        `{"query":"{ hero(limit: 123) { name } }"}`,
+			validators:  []Validator{&LimitValidator{limit: 100}},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: ErrLimitTooLarge.Error(),
+		},
+		{
+			name:       "limit ok",
+			body:       `{"query":"{ hero(limit: 100) { name } }"}`,
+			validators: []Validator{&LimitValidator{limit: 100}},
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero(limit: 100) { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
+			},
+			wantStatus:  http.StatusOK,
+			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
+		},
+		{
+			name:        "limit ok, mock validation error",
+			body:        `{"query":"{ hero(limit: 10) { name } }"}`,
+			validators:  []Validator{&LimitValidator{limit: 100}, &failValidator{}},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: errFail.Error(),
+		},
 	}
 
 	for _, c := range cases {
@@ -321,7 +378,7 @@ func TestHandler(t *testing.T) {
 				c.setupSelector(sel, []host.Host{host.Host(okHost.URL)})
 			}
 
-			h := NewHandler(nil, ext, sel, logger)
+			h := NewHandler(c.validators, ext, sel, logger)
 
 			accept := c.accept
 			if accept == "" {
@@ -737,9 +794,7 @@ func TestHandlerForwardsHostAndAuth(t *testing.T) {
 
 func mustParseQuery(t *testing.T, graphql string) *ast.QueryDocument {
 	t.Helper()
-	ast, err := parseQuery(graphql)
-	if err != nil {
-		t.Fail()
-	}
-	return ast
+	query, err := parseQuery(graphql)
+	require.NoError(t, err)
+	return query
 }

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -44,7 +44,7 @@ func (m *mockSelector) SelectHosts(ctx context.Context, collections []string) ([
 
 type failValidator struct{}
 
-func (*failValidator) Validate(req *ValidationRequest) error {
+func (*failValidator) Validate(*ValidationRequest) error {
 	return errFail
 }
 
@@ -320,28 +320,28 @@ func TestHandler(t *testing.T) {
 		{
 			name:        "missing limit",
 			body:        `{"query":"{ hero { name } }"}`,
-			validators:  []Validator{&LimitValidator{limit: 100}},
+			validators:  []Validator{NewLimitValidator(100)},
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: ErrMissingLimit.Error(),
 		},
 		{
 			name:        "invalid limit",
 			body:        `{"query":"{ hero(limit: -1) { name } }"}`,
-			validators:  []Validator{&LimitValidator{limit: 100}},
+			validators:  []Validator{NewLimitValidator(100)},
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: ErrInvalidLimit.Error(),
 		},
 		{
 			name:        "limit exceeded",
 			body:        `{"query":"{ hero(limit: 123) { name } }"}`,
-			validators:  []Validator{&LimitValidator{limit: 100}},
+			validators:  []Validator{NewLimitValidator(100)},
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: ErrLimitTooLarge.Error(),
 		},
 		{
 			name:       "limit ok",
 			body:       `{"query":"{ hero(limit: 100) { name } }"}`,
-			validators: []Validator{&LimitValidator{limit: 100}},
+			validators: []Validator{NewLimitValidator(100)},
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero(limit: 100) { name } }")).Return([]string{"hero"}, nil)
 			},
@@ -354,7 +354,7 @@ func TestHandler(t *testing.T) {
 		{
 			name:        "limit ok, mock validation error",
 			body:        `{"query":"{ hero(limit: 10) { name } }"}`,
-			validators:  []Validator{&LimitValidator{limit: 100}, &failValidator{}},
+			validators:  []Validator{NewLimitValidator(100), &failValidator{}},
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: errFail.Error(),
 		},

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
 	"go.uber.org/zap"
 
 	"github.com/shinzonetwork/shinzo-network-gateway/host"
 )
 
 var (
-	errParse   = errors.New("parse error")
 	errNoHosts = errors.New("no hosts")
 	errFail    = errors.New("fail")
 )
@@ -28,7 +28,7 @@ type mockExtractor struct {
 	mock.Mock
 }
 
-func (m *mockExtractor) ExtractCollections(graphql string) ([]string, error) {
+func (m *mockExtractor) ExtractCollections(graphql *ast.QueryDocument) ([]string, error) {
 	args := m.Called(graphql)
 	return args.Get(0).([]string), args.Error(1)
 }
@@ -265,11 +265,8 @@ func TestHandler(t *testing.T) {
 			wantBodyHas:    "unsupported Content-Type",
 		},
 		{
-			name: "extractor error",
-			body: `{"query":"bad"}`,
-			setupExtractor: func(ext *mockExtractor) {
-				ext.On("ExtractCollections", "bad").Return([]string(nil), errParse)
-			},
+			name:        "extractor error",
+			body:        `{"query":"bad"}`,
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "parse error",
 		},
@@ -277,7 +274,7 @@ func TestHandler(t *testing.T) {
 			name: "selector error",
 			body: `{"query":"{ hero { name } }"}`,
 			setupExtractor: func(ext *mockExtractor) {
-				ext.On("ExtractCollections", "{ hero { name } }").Return([]string{"hero"}, nil)
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, _ []host.Host) {
 				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return([]host.Host(nil), errNoHosts)
@@ -289,7 +286,7 @@ func TestHandler(t *testing.T) {
 			name: "successful query",
 			body: `{"query":"{ hero { name } }"}`,
 			setupExtractor: func(ext *mockExtractor) {
-				ext.On("ExtractCollections", "{ hero { name } }").Return([]string{"hero"}, nil)
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
 				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
@@ -298,12 +295,9 @@ func TestHandler(t *testing.T) {
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
 		},
 		{
-			name:   "legacy content type uses 200 for request errors",
-			body:   `{"query":"bad"}`,
-			accept: "application/json",
-			setupExtractor: func(ext *mockExtractor) {
-				ext.On("ExtractCollections", "bad").Return([]string(nil), errParse)
-			},
+			name:        "legacy content type uses 200 for request errors",
+			body:        `{"query":"bad"}`,
+			accept:      "application/json",
 			wantStatus:  http.StatusOK,
 			wantBodyHas: "parse error",
 		},
@@ -739,4 +733,13 @@ func TestHandlerForwardsHostAndAuth(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	backend.AssertExpectations(t)
+}
+
+func mustParseQuery(t *testing.T, graphql string) *ast.QueryDocument {
+	t.Helper()
+	ast, err := parseQuery(graphql)
+	if err != nil {
+		t.Fail()
+	}
+	return ast
 }

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -358,6 +358,19 @@ func TestHandler(t *testing.T) {
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: errFail.Error(),
 		},
+		{
+			name:       "limit ok, order ok",
+			body:       `{"query":"{ hero(limit: 10, order: {name: ASC}) { name } }"}`,
+			validators: []Validator{NewLimitValidator(100), &OrderValidator{}},
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mock.Anything).Return([]string{"hero"}, nil)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
+			},
+			wantStatus:  http.StatusOK,
+			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
+		},
 	}
 
 	for _, c := range cases {

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -336,7 +336,7 @@ func TestHandler(t *testing.T) {
 			body:        `{"query":"{ hero(limit: 123) { name } }"}`,
 			validators:  []Validator{NewLimitValidator(100)},
 			wantStatus:  http.StatusBadRequest,
-			wantBodyHas: ErrLimitTooLarge.Error(),
+			wantBodyHas: ErrInvalidLimit.Error(),
 		},
 		{
 			name:       "limit ok",

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -182,7 +182,7 @@ func TestHandlerGetHostsResponses(t *testing.T) {
 			th := setupTestHosts(c.kinds)
 			defer th.cleanup()
 
-			h := NewHandler(nil, nil, logger)
+			h := NewHandler(nil, nil, nil, logger)
 			require.NotNil(t, h)
 
 			timeout := c.timeout
@@ -321,7 +321,7 @@ func TestHandler(t *testing.T) {
 				c.setupSelector(sel, []host.Host{host.Host(okHost.URL)})
 			}
 
-			h := NewHandler(ext, sel, logger)
+			h := NewHandler(nil, ext, sel, logger)
 
 			accept := c.accept
 			if accept == "" {
@@ -588,7 +588,7 @@ func TestComposeResponse(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := NewHandler(nil, nil, logger)
+			h := NewHandler(nil, nil, nil, logger)
 			w := httptest.NewRecorder()
 
 			h.composeResponse(w, c.responses, c.contentType)
@@ -720,7 +720,7 @@ func TestHandlerForwardsHostAndAuth(t *testing.T) {
 	sel.On("SelectHosts", mock.Anything, []string{collection}).Return([]host.Host{host.Host(srv.URL)}, nil)
 
 	logger, _ := zap.NewDevelopment()
-	h := NewHandler(ext, sel, logger)
+	h := NewHandler(nil, ext, sel, logger)
 
 	req := httptest.NewRequest(http.MethodPost, "http://"+originalHost+"/graphql", strings.NewReader(`{"query":"{ TestView { id } }"}`))
 	req.Host = originalHost

--- a/endpoint/parser.go
+++ b/endpoint/parser.go
@@ -17,3 +17,20 @@ func parseQuery(graphql string) (*ast.QueryDocument, error) {
 	}
 	return query, nil
 }
+
+// rootFields returns the root-level field selections for every operation in query.
+// It returns ErrUnsupportedSelection if a root selection is not a plain field
+// (a fragment spread or inline fragment).
+func rootFields(query *ast.QueryDocument) ([]*ast.Field, error) {
+	var fields []*ast.Field
+	for _, op := range query.Operations {
+		for _, sel := range op.SelectionSet {
+			field, ok := sel.(*ast.Field)
+			if !ok {
+				return nil, fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
+			}
+			fields = append(fields, field)
+		}
+	}
+	return fields, nil
+}

--- a/endpoint/parser.go
+++ b/endpoint/parser.go
@@ -1,0 +1,19 @@
+package endpoint
+
+import (
+	"fmt"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+)
+
+func parseQuery(graphql string) (*ast.QueryDocument, error) {
+	if len(graphql) == 0 {
+		return nil, ErrEmptyQuery
+	}
+	ast, err := parser.ParseQuery(&ast.Source{Input: graphql})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrParse, err)
+	}
+	return ast, nil
+}

--- a/endpoint/parser.go
+++ b/endpoint/parser.go
@@ -11,9 +11,9 @@ func parseQuery(graphql string) (*ast.QueryDocument, error) {
 	if len(graphql) == 0 {
 		return nil, ErrEmptyQuery
 	}
-	ast, err := parser.ParseQuery(&ast.Source{Input: graphql})
+	query, err := parser.ParseQuery(&ast.Source{Input: graphql})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrParse, err)
 	}
-	return ast, nil
+	return query, nil
 }

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -40,7 +40,7 @@ func (v *LimitValidator) Validate(req *ValidationRequest) error {
 		for _, sel := range op.SelectionSet {
 			field, ok := sel.(*ast.Field)
 			if !ok {
-				continue
+				return fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
 			}
 			arg := field.Arguments.ForName("limit")
 			if arg == nil {

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -84,3 +84,88 @@ func (v *LimitValidator) checkLimit(field string, val *ast.Value) error {
 	}
 	return nil
 }
+
+// OrderValidator ensures every root field specifies proper ordering.
+type OrderValidator struct{}
+
+var _ Validator = &OrderValidator{}
+
+// Validate checks that each root field carries a valid limit argument.
+func (v *OrderValidator) Validate(req *ValidationRequest) error {
+	for _, op := range req.Query.Operations {
+		for _, sel := range op.SelectionSet {
+			field, ok := sel.(*ast.Field)
+			if !ok {
+				return fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
+			}
+			orders := 0
+			var arg *ast.Argument
+			for _, a := range field.Arguments {
+				if a.Name == "order" {
+					orders++
+					arg = a
+				}
+			}
+			switch orders {
+			case 0:
+				return fmt.Errorf("%w: %s", ErrMissingOrder, field.Name)
+			case 1:
+				if err := v.checkOrder(field.Name, arg.Value); err != nil {
+					return err
+				}
+
+			default: // orders > 1
+				return fmt.Errorf("%w: %s: duplicate order argument", ErrInvalidOrder, field.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// checkOrder verifies that an order argument is a DefraDB-compatible ordering:
+// - a single {field: ASC|DESC} object,
+// - a list of such single-field objects (for multi-field ordering, where position is significant),
+// - a nested {relation: {field: ASC|DESC}} objects for ordering on a related collection.
+func (v *OrderValidator) checkOrder(field string, value *ast.Value) error {
+	if value == nil {
+		return fmt.Errorf("%w: %s: order must be an object or list", ErrInvalidOrder, field)
+	}
+	if value.Kind == ast.ObjectValue {
+		return checkOrderObject(field, value)
+	}
+	if value.Kind != ast.ListValue {
+		return fmt.Errorf("%w: %s: order must be an object or list", ErrInvalidOrder, field)
+	}
+	if len(value.Children) == 0 {
+		return fmt.Errorf("%w: %s: order list must not be empty", ErrInvalidOrder, field)
+	}
+	for _, child := range value.Children {
+		if child.Value.Kind != ast.ObjectValue {
+			return fmt.Errorf("%w: %s: order list elements must be objects", ErrInvalidOrder, field)
+		}
+		if err := checkOrderObject(field, child.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkOrderObject(field string, value *ast.Value) error {
+	if len(value.Children) != 1 {
+		return fmt.Errorf("%w: %s: each order object must specify exactly one field", ErrInvalidOrder, field)
+	}
+	return checkOrderValue(field, value.Children[0].Value)
+}
+
+func checkOrderValue(field string, value *ast.Value) error {
+	if value.Kind == ast.ObjectValue {
+		return checkOrderObject(field, value)
+	}
+	if value.Kind != ast.EnumValue {
+		return fmt.Errorf("%w: %s: order value must be ASC, DESC, or a nested object", ErrInvalidOrder, field)
+	}
+	if value.Raw != "ASC" && value.Raw != "DESC" {
+		return fmt.Errorf("%w: %s: direction must be ASC or DESC, got %s", ErrInvalidOrder, field, value.Raw)
+	}
+	return nil
+}

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -27,6 +27,13 @@ type LimitValidator struct {
 
 var _ Validator = &LimitValidator{}
 
+// NewLimitValidator creates configured instance of LimitValidator.
+func NewLimitValidator(limit int) *LimitValidator {
+	return &LimitValidator{
+		limit: limit,
+	}
+}
+
 // Validate checks that each root field carries a valid limit argument.
 func (v *LimitValidator) Validate(req *ValidationRequest) error {
 	for _, op := range req.Query.Operations {

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -42,12 +42,23 @@ func (v *LimitValidator) Validate(req *ValidationRequest) error {
 			if !ok {
 				return fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
 			}
-			arg := field.Arguments.ForName("limit")
-			if arg == nil {
-				return fmt.Errorf("%w: %s", ErrMissingLimit, field.Name)
+			limits := 0
+			var arg *ast.Argument
+			for _, a := range field.Arguments {
+				if a.Name == "limit" {
+					limits++
+					arg = a
+				}
 			}
-			if err := v.checkLimit(field.Name, arg.Value); err != nil {
-				return err
+			switch limits {
+			case 0:
+				return fmt.Errorf("%w: %s", ErrMissingLimit, field.Name)
+			case 1:
+				if err := v.checkLimit(field.Name, arg.Value); err != nil {
+					return err
+				}
+			default: // limits > 1
+				return fmt.Errorf("%w: %s: duplicate limit argument", ErrInvalidLimit, field.Name)
 			}
 		}
 	}
@@ -59,15 +70,17 @@ func (v *LimitValidator) checkLimit(field string, val *ast.Value) error {
 	if val == nil || val.Kind != ast.IntValue {
 		return fmt.Errorf("%w: %s: limit must be an integer literal", ErrInvalidLimit, field)
 	}
-	n, err := strconv.Atoi(val.Raw)
+	// GraphQL Int is a signed 32-bit value; parse with that bound so out-of-range
+	// literals are rejected rather than silently forwarded as invalid Ints.
+	n, err := strconv.ParseInt(val.Raw, 10, 32)
 	if err != nil {
 		return fmt.Errorf("%w: %s: %w", ErrInvalidLimit, field, err)
 	}
 	if n <= 0 {
 		return fmt.Errorf("%w: %s: limit must be positive, got %d", ErrInvalidLimit, field, n)
 	}
-	if n > v.limit {
-		return fmt.Errorf("%w: %s: limit %d exceeds maximum %d", ErrLimitTooLarge, field, n, v.limit)
+	if n > int64(v.limit) {
+		return fmt.Errorf("%w: %s: limit %d exceeds maximum %d", ErrInvalidLimit, field, n, v.limit)
 	}
 	return nil
 }

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -1,0 +1,66 @@
+package endpoint
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// Validator validates a parsed GraphQL request before it is forwarded upstream.
+type Validator interface {
+	Validate(req *ValidationRequest) error
+}
+
+// ValidationRequest contains the parsed query and request headers to validate.
+type ValidationRequest struct {
+	Query  *ast.QueryDocument
+	Header http.Header
+}
+
+// LimitValidator ensures every root field specifies a positive limit argument
+// not exceeding the configured maximum.
+type LimitValidator struct {
+	limit int
+}
+
+var _ Validator = &LimitValidator{}
+
+// Validate checks that each root field carries a valid limit argument.
+func (v *LimitValidator) Validate(req *ValidationRequest) error {
+	for _, op := range req.Query.Operations {
+		for _, sel := range op.SelectionSet {
+			field, ok := sel.(*ast.Field)
+			if !ok {
+				continue
+			}
+			arg := field.Arguments.ForName("limit")
+			if arg == nil {
+				return fmt.Errorf("%w: %s", ErrMissingLimit, field.Name)
+			}
+			if err := v.checkLimit(field.Name, arg.Value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkLimit verifies that a limit argument has a positive integer literal within limit.
+func (v *LimitValidator) checkLimit(field string, val *ast.Value) error {
+	if val == nil || val.Kind != ast.IntValue {
+		return fmt.Errorf("%w: %s: limit must be an integer literal", ErrInvalidLimit, field)
+	}
+	n, err := strconv.Atoi(val.Raw)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrInvalidLimit, field, err)
+	}
+	if n <= 0 {
+		return fmt.Errorf("%w: %s: limit must be positive, got %d", ErrInvalidLimit, field, n)
+	}
+	if n > v.limit {
+		return fmt.Errorf("%w: %s: limit %d exceeds maximum %d", ErrLimitTooLarge, field, n, v.limit)
+	}
+	return nil
+}

--- a/endpoint/validator.go
+++ b/endpoint/validator.go
@@ -36,30 +36,28 @@ func NewLimitValidator(limit int) *LimitValidator {
 
 // Validate checks that each root field carries a valid limit argument.
 func (v *LimitValidator) Validate(req *ValidationRequest) error {
-	for _, op := range req.Query.Operations {
-		for _, sel := range op.SelectionSet {
-			field, ok := sel.(*ast.Field)
-			if !ok {
-				return fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
+	fields, err := rootFields(req.Query)
+	if err != nil {
+		return err
+	}
+	for _, field := range fields {
+		limits := 0
+		var arg *ast.Argument
+		for _, a := range field.Arguments {
+			if a.Name == "limit" {
+				limits++
+				arg = a
 			}
-			limits := 0
-			var arg *ast.Argument
-			for _, a := range field.Arguments {
-				if a.Name == "limit" {
-					limits++
-					arg = a
-				}
+		}
+		switch limits {
+		case 0:
+			return fmt.Errorf("%w: %s", ErrMissingLimit, field.Name)
+		case 1:
+			if err := v.checkLimit(field.Name, arg.Value); err != nil {
+				return err
 			}
-			switch limits {
-			case 0:
-				return fmt.Errorf("%w: %s", ErrMissingLimit, field.Name)
-			case 1:
-				if err := v.checkLimit(field.Name, arg.Value); err != nil {
-					return err
-				}
-			default: // limits > 1
-				return fmt.Errorf("%w: %s: duplicate limit argument", ErrInvalidLimit, field.Name)
-			}
+		default: // limits > 1
+			return fmt.Errorf("%w: %s: duplicate limit argument", ErrInvalidLimit, field.Name)
 		}
 	}
 	return nil
@@ -90,33 +88,30 @@ type OrderValidator struct{}
 
 var _ Validator = &OrderValidator{}
 
-// Validate checks that each root field carries a valid limit argument.
+// Validate checks that each root field carries a valid order argument.
 func (v *OrderValidator) Validate(req *ValidationRequest) error {
-	for _, op := range req.Query.Operations {
-		for _, sel := range op.SelectionSet {
-			field, ok := sel.(*ast.Field)
-			if !ok {
-				return fmt.Errorf("%w: %T", ErrUnsupportedSelection, sel)
+	fields, err := rootFields(req.Query)
+	if err != nil {
+		return err
+	}
+	for _, field := range fields {
+		orders := 0
+		var arg *ast.Argument
+		for _, a := range field.Arguments {
+			if a.Name == "order" {
+				orders++
+				arg = a
 			}
-			orders := 0
-			var arg *ast.Argument
-			for _, a := range field.Arguments {
-				if a.Name == "order" {
-					orders++
-					arg = a
-				}
+		}
+		switch orders {
+		case 0:
+			return fmt.Errorf("%w: %s", ErrMissingOrder, field.Name)
+		case 1:
+			if err := v.checkOrder(field.Name, arg.Value); err != nil {
+				return err
 			}
-			switch orders {
-			case 0:
-				return fmt.Errorf("%w: %s", ErrMissingOrder, field.Name)
-			case 1:
-				if err := v.checkOrder(field.Name, arg.Value); err != nil {
-					return err
-				}
-
-			default: // orders > 1
-				return fmt.Errorf("%w: %s: duplicate order argument", ErrInvalidOrder, field.Name)
-			}
+		default: // orders > 1
+			return fmt.Errorf("%w: %s: duplicate order argument", ErrInvalidOrder, field.Name)
 		}
 	}
 	return nil

--- a/endpoint/validator_test.go
+++ b/endpoint/validator_test.go
@@ -130,3 +130,132 @@ func TestLimitValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestOrderValidator(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		query string
+		err   error
+	}{
+		{
+			name:  "valid single field ascending",
+			query: `{ users(order: {name: ASC}) { id } }`,
+		},
+		{
+			name:  "valid single field descending",
+			query: `{ users(order: {created: DESC}) { id } }`,
+		},
+		{
+			name:  "valid multi-field list",
+			query: `{ users(order: [{name: ASC}, {age: DESC}]) { id } }`,
+		},
+		{
+			name:  "valid nested relation order",
+			query: `{ users(order: {author: {birthday: DESC}}) { id } }`,
+		},
+		{
+			name:  "valid nested relation inside list",
+			query: `{ users(order: [{name: ASC}, {author: {birthday: DESC}}]) { id } }`,
+		},
+		{
+			name:  "multiple root fields all valid",
+			query: `{ users(order: {name: ASC}) { id } posts(order: {title: DESC}) { id } }`,
+		},
+		{
+			name:  "nested field without order is allowed",
+			query: `{ users(order: {name: ASC}) { id posts { id } } }`,
+		},
+		{
+			name:  "missing order",
+			query: `{ users { id } }`,
+			err:   ErrMissingOrder,
+		},
+		{
+			name:  "multiple root fields one missing order",
+			query: `{ users(order: {name: ASC}) { id } posts { id } }`,
+			err:   ErrMissingOrder,
+		},
+		{
+			name:  "duplicate order argument",
+			query: `{ users(order: {name: ASC}, order: {age: DESC}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "object with multiple fields is rejected",
+			query: `{ users(order: {name: ASC, age: DESC}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "empty order object",
+			query: `{ users(order: {}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "empty order list",
+			query: `{ users(order: []) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "unknown direction",
+			query: `{ users(order: {name: ASCENDING}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "direction as string",
+			query: `{ users(order: {name: "ASC"}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "order as scalar",
+			query: `{ users(order: 5) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "order as variable",
+			query: `query ($o: ordering) { users(order: $o) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "list element is not an object",
+			query: `{ users(order: [ASC]) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "nested relation unknown direction",
+			query: `{ users(order: {author: {birthday: SIDEWAYS}}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "nested relation with multiple fields is rejected",
+			query: `{ users(order: {author: {name: ASC, birthday: DESC}}) { id } }`,
+			err:   ErrInvalidOrder,
+		},
+		{
+			name:  "root inline fragment is rejected",
+			query: `{ ... on Query { users(order: {name: ASC}) { id } } }`,
+			err:   ErrUnsupportedSelection,
+		},
+		{
+			name:  "root fragment spread is rejected",
+			query: `{ ...Roots } fragment Roots on Query { users(order: {name: ASC}) { id } }`,
+			err:   ErrUnsupportedSelection,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query, err := parseQuery(tc.query)
+			require.NoError(t, err)
+
+			validator := &OrderValidator{}
+
+			err = validator.Validate(&ValidationRequest{Query: query})
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/endpoint/validator_test.go
+++ b/endpoint/validator_test.go
@@ -86,12 +86,12 @@ func TestLimitValidator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ast, err := parseQuery(tc.query)
+			query, err := parseQuery(tc.query)
 			require.NoError(t, err)
 
 			validator := &LimitValidator{limit: tc.limit}
 
-			err = validator.Validate(&ValidationRequest{Query: ast})
+			err = validator.Validate(&ValidationRequest{Query: query})
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {

--- a/endpoint/validator_test.go
+++ b/endpoint/validator_test.go
@@ -82,6 +82,18 @@ func TestLimitValidator(t *testing.T) {
 			limit: 100,
 			query: `{ users(limit: 10) { id posts { id } } }`,
 		},
+		{
+			name:  "root inline fragment is rejected",
+			limit: 100,
+			query: `{ ... on Query { users(limit: 10) { id } } }`,
+			err:   ErrUnsupportedSelection,
+		},
+		{
+			name:  "root fragment spread is rejected",
+			limit: 100,
+			query: `{ ...Roots } fragment Roots on Query { users(limit: 10) { id } }`,
+			err:   ErrUnsupportedSelection,
+		},
 	}
 
 	for _, tc := range cases {

--- a/endpoint/validator_test.go
+++ b/endpoint/validator_test.go
@@ -28,7 +28,7 @@ func TestLimitValidator(t *testing.T) {
 			name:  "limit over range",
 			limit: 100,
 			query: `{ users(limit: 101) { id } }`,
-			err:   ErrLimitTooLarge,
+			err:   ErrInvalidLimit,
 		},
 		{
 			name:  "negative limit",
@@ -65,6 +65,24 @@ func TestLimitValidator(t *testing.T) {
 			limit: 100,
 			query: `{ users { id } }`,
 			err:   ErrMissingLimit,
+		},
+		{
+			name:  "duplicate limit argument",
+			limit: 100,
+			query: `{ users(limit: 1, limit: 9999999) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit exceeds int32 range",
+			limit: 100,
+			query: `{ users(limit: 3000000000) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit below int32 range",
+			limit: 100,
+			query: `{ users(limit: -3000000000) { id } }`,
+			err:   ErrInvalidLimit,
 		},
 		{
 			name:  "multiple root fields all valid",

--- a/endpoint/validator_test.go
+++ b/endpoint/validator_test.go
@@ -1,0 +1,102 @@
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitValidator(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		limit int
+		query string
+		err   error
+	}{
+		{
+			name:  "valid limit",
+			limit: 100,
+			query: `{ users(limit: 10) { id } }`,
+		},
+		{
+			name:  "limit equal to max",
+			limit: 100,
+			query: `{ users(limit: 100) { id } }`,
+		},
+		{
+			name:  "limit over range",
+			limit: 100,
+			query: `{ users(limit: 101) { id } }`,
+			err:   ErrLimitTooLarge,
+		},
+		{
+			name:  "negative limit",
+			limit: 100,
+			query: `{ users(limit: -5) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit equal to zero",
+			limit: 100,
+			query: `{ users(limit: 0) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit as string",
+			limit: 100,
+			query: `{ users(limit: "10") { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit as float",
+			limit: 100,
+			query: `{ users(limit: 1.5) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "limit as variable",
+			limit: 100,
+			query: `query ($n: Int) { users(limit: $n) { id } }`,
+			err:   ErrInvalidLimit,
+		},
+		{
+			name:  "missing limit",
+			limit: 100,
+			query: `{ users { id } }`,
+			err:   ErrMissingLimit,
+		},
+		{
+			name:  "multiple root fields all valid",
+			limit: 100,
+			query: `{ users(limit: 10) { id } posts(limit: 20) { id } }`,
+		},
+		{
+			name:  "multiple root fields one missing limit",
+			limit: 100,
+			query: `{ users(limit: 10) { id } posts { id } }`,
+			err:   ErrMissingLimit,
+		},
+		{
+			name:  "nested field without limit is allowed",
+			limit: 100,
+			query: `{ users(limit: 10) { id posts { id } } }`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, err := parseQuery(tc.query)
+			require.NoError(t, err)
+
+			validator := &LimitValidator{limit: tc.limit}
+
+			err = validator.Validate(&ValidationRequest{Query: ast})
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces `Validator` interface for clean separation of logic related to validation of certain aspects of requests.

`LimitValidator` ensures that queries have a limit within configured range.
`OrderValidator` ensures that queries have proper ordering set.

Parsing function was extracted from `CollectionsExtractor`, to ensure that AST is built once per query. 

Resolves #74.