### PR TITLE
feat: per-query sample size configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,7 @@ linters:
   settings:
     funlen:
       lines: 100
+      statements: 50
     revive:
       enable-default-rules: true
       rules:

--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -74,7 +74,8 @@ func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 	)
 
 	validators := []endpoint.Validator{endpoint.NewLimitValidator(maxLimit), &endpoint.OrderValidator{}}
-	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, logger)
+	sampleSize := a.v.GetInt(flagSample)
+	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, sampleSize, logger)
 	endp, err := endpoint.New(a.v.GetString(flagListen), handler, logger)
 	if err != nil {
 		return fmt.Errorf("error while creating endpoint: %w", err)

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -22,7 +22,7 @@ import (
 
 // HostsSelector interface allows handler to get hosts for given collections.
 type HostsSelector interface {
-	SelectHosts(ctx context.Context, collections []string) ([]host.Host, error)
+	SelectHosts(ctx context.Context, n int, collections []string) ([]host.Host, error)
 }
 
 // Handler is a HTTP handler for "POST /graphql" endpoint.
@@ -32,6 +32,8 @@ type Handler struct {
 	selector   HostsSelector
 	client     *http.Client
 	logger     *zap.Logger
+
+	defaultSampleSize int
 }
 
 var _ http.Handler = &Handler{}
@@ -60,18 +62,19 @@ type hostResponse struct {
 }
 
 // NewHandler creates new Handler instance.
-func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, logger *zap.Logger) *Handler {
+func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, defaultSampleSize int, logger *zap.Logger) *Handler {
 	transport := &http.Transport{
 		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 
 	return &Handler{
-		validators: validators,
-		extractor:  extractor,
-		selector:   selector,
-		client:     &http.Client{Transport: transport},
-		logger:     logger.Named("handler"),
+		validators:        validators,
+		extractor:         extractor,
+		selector:          selector,
+		client:            &http.Client{Transport: transport},
+		logger:            logger.Named("handler"),
+		defaultSampleSize: defaultSampleSize,
 	}
 }
 
@@ -127,7 +130,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hosts, err := h.selector.SelectHosts(r.Context(), collections)
+	n := h.getHostsNumber(gqlReq.Extensions)
+	hosts, err := h.selector.SelectHosts(r.Context(), n, collections)
 	if err != nil {
 		h.writeError(w, http.StatusServiceUnavailable, err.Error(), contentType)
 		return
@@ -136,6 +140,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	responses := h.getHostsResponses(r.Context(), hosts, body, r.Host, r.Header.Get("Authorization"))
 
 	h.composeResponse(w, responses, contentType)
+}
+
+func (h *Handler) getHostsNumber(extensions json.RawMessage) int {
+	if extensions != nil {
+		// TODO(tzdybal): read sample size from extensions
+	}
+	return h.defaultSampleSize
 }
 
 func (h *Handler) getHostsResponses(ctx context.Context, hosts []host.Host, body []byte, hostHeader, authHeader string) []hostResponse {

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -61,6 +61,16 @@ type hostResponse struct {
 	err      error
 }
 
+// extensions is a copy of Extensions from https://github.com/shinzonetwork/shinzo-querysig/blob/main/billing/
+// The entire dependency tree of shinozo-querysig is to huge to import.
+type extensions struct {
+	RequestSignature string `json:"request_signature"`
+	Nonce            string `json:"nonce"`
+	QueryHash        string `json:"query_hash"`
+	RequestTimestamp uint64 `json:"request_timestamp"`
+	Fanout           int    `json:"fanout"`
+}
+
 // NewHandler creates new Handler instance.
 func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, defaultSampleSize int, logger *zap.Logger) *Handler {
 	transport := &http.Transport{
@@ -130,7 +140,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	n := h.getHostsNumber(gqlReq.Extensions)
+	n, err := h.getFanout(gqlReq.Extensions)
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid extensions", contentType)
+		return
+	}
 	hosts, err := h.selector.SelectHosts(r.Context(), n, collections)
 	if err != nil {
 		h.writeError(w, http.StatusServiceUnavailable, err.Error(), contentType)
@@ -142,11 +156,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.composeResponse(w, responses, contentType)
 }
 
-func (h *Handler) getHostsNumber(extensions json.RawMessage) int {
-	if extensions != nil {
-		// TODO(tzdybal): read sample size from extensions
+func (h *Handler) getFanout(ext json.RawMessage) (int, error) {
+	fanout := h.defaultSampleSize
+	if ext != nil {
+		var deserialized extensions
+		err := json.Unmarshal(ext, &deserialized)
+		if err != nil {
+			return 0, err
+		}
+		if deserialized.Fanout > 0 {
+			fanout = deserialized.Fanout
+		}
 	}
-	return h.defaultSampleSize
+	return fanout, nil
 }
 
 func (h *Handler) getHostsResponses(ctx context.Context, hosts []host.Host, body []byte, hostHeader, authHeader string) []hostResponse {

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/shinzonetwork/shinzo-network-gateway/host"
 )
 
+const defaultSampleSize = 3
+
 var (
 	errNoHosts = errors.New("no hosts")
 	errFail    = errors.New("fail")
@@ -37,8 +39,8 @@ type mockSelector struct {
 	mock.Mock
 }
 
-func (m *mockSelector) SelectHosts(ctx context.Context, collections []string) ([]host.Host, error) {
-	args := m.Called(ctx, collections)
+func (m *mockSelector) SelectHosts(ctx context.Context, n int, collections []string) ([]host.Host, error) {
+	args := m.Called(ctx, n, collections)
 	return args.Get(0).([]host.Host), args.Error(1)
 }
 
@@ -188,7 +190,7 @@ func TestHandlerGetHostsResponses(t *testing.T) {
 			th := setupTestHosts(c.kinds)
 			defer th.cleanup()
 
-			h := NewHandler(nil, nil, nil, logger)
+			h := NewHandler(nil, nil, nil, defaultSampleSize, logger)
 			require.NotNil(t, h)
 
 			timeout := c.timeout
@@ -293,7 +295,7 @@ func TestHandler(t *testing.T) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, _ []host.Host) {
-				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return([]host.Host(nil), errNoHosts)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return([]host.Host(nil), errNoHosts)
 			},
 			wantStatus:  http.StatusServiceUnavailable,
 			wantBodyHas: "no hosts",
@@ -305,7 +307,7 @@ func TestHandler(t *testing.T) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -346,7 +348,7 @@ func TestHandler(t *testing.T) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero(limit: 100) { name } }")).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -366,7 +368,7 @@ func TestHandler(t *testing.T) {
 				ext.On("ExtractCollections", mock.Anything).Return([]string{"hero"}, nil)
 			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -391,7 +393,7 @@ func TestHandler(t *testing.T) {
 				c.setupSelector(sel, []host.Host{host.Host(okHost.URL)})
 			}
 
-			h := NewHandler(c.validators, ext, sel, logger)
+			h := NewHandler(c.validators, ext, sel, defaultSampleSize, logger)
 
 			accept := c.accept
 			if accept == "" {
@@ -658,7 +660,7 @@ func TestComposeResponse(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := NewHandler(nil, nil, nil, logger)
+			h := NewHandler(nil, nil, nil, defaultSampleSize, logger)
 			w := httptest.NewRecorder()
 
 			h.composeResponse(w, c.responses, c.contentType)
@@ -787,10 +789,10 @@ func TestHandlerForwardsHostAndAuth(t *testing.T) {
 	ext.On("ExtractCollections", mock.Anything).Return([]string{collection}, nil)
 
 	sel := &mockSelector{}
-	sel.On("SelectHosts", mock.Anything, []string{collection}).Return([]host.Host{host.Host(srv.URL)}, nil)
+	sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{collection}).Return([]host.Host{host.Host(srv.URL)}, nil)
 
 	logger, _ := zap.NewDevelopment()
-	h := NewHandler(nil, ext, sel, logger)
+	h := NewHandler(nil, ext, sel, defaultSampleSize, logger)
 
 	req := httptest.NewRequest(http.MethodPost, "http://"+originalHost+"/graphql", strings.NewReader(`{"query":"{ TestView { id } }"}`))
 	req.Host = originalHost

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -373,6 +373,39 @@ func TestHandler(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
 		},
+		{
+			name: "fanout from extensions overrides default sample size",
+			body: `{"query":"{ hero { name } }","extensions":{"fanout":5}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, 5, []string{"hero"}).Return(hosts, nil)
+			},
+			wantStatus:  http.StatusOK,
+			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
+		},
+		{
+			name: "zero fanout in extensions falls back to default sample size",
+			body: `{"query":"{ hero { name } }","extensions":{"fanout":0}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
+			},
+			wantStatus:  http.StatusOK,
+			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
+		},
+		{
+			name: "malformed extensions is a bad request",
+			body: `{"query":"{ hero { name } }","extensions":"not an object"}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: "invalid extensions",
+		},
 	}
 
 	for _, c := range cases {

--- a/router/router.go
+++ b/router/router.go
@@ -55,7 +55,7 @@ func (r *Router) SelectHosts(_ context.Context, n int, collections []string) ([]
 		return nil, ErrPoolNotFound
 	}
 
-	// return configured number of hosts, or all of them
+	// return requested number of hosts, or all of them
 	l := min(n, len(pool.hosts.Pool()))
 	return pool.get(l)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -10,11 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// TODO(tzdybal): this has to be configurable.
-	sampleSize = 3
-)
-
 var (
 	// ErrPoolNotSupported is returned if requested type of pool is not supported by Router.
 	ErrPoolNotSupported = errors.New("only single-collection pools are supported")
@@ -46,7 +41,7 @@ func New(logger *zap.Logger) *Router {
 }
 
 // SelectHosts finds the hosts that serve all the collections, and return random sample.
-func (r *Router) SelectHosts(_ context.Context, collections []string) ([]host.Host, error) {
+func (r *Router) SelectHosts(_ context.Context, n int, collections []string) ([]host.Host, error) {
 	if len(collections) != 1 {
 		return nil, ErrPoolNotSupported
 	}
@@ -61,7 +56,7 @@ func (r *Router) SelectHosts(_ context.Context, collections []string) ([]host.Ho
 	}
 
 	// return configured number of hosts, or all of them
-	l := min(sampleSize, len(pool.hosts.Pool()))
+	l := min(n, len(pool.hosts.Pool()))
 	return pool.get(l)
 }
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/shinzonetwork/shinzo-network-gateway/host"
 )
 
+const defaultSampleSize = 3
+
 func TestSelectHosts(t *testing.T) {
 	t.Parallel()
 
@@ -71,7 +73,7 @@ func TestSelectHosts(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
-			actual, err := r.SelectHosts(ctx, c.colls)
+			actual, err := r.SelectHosts(ctx, defaultSampleSize, c.colls)
 			if c.err != nil {
 				require.ErrorIs(t, err, c.err)
 				require.Nil(t, actual)
@@ -90,7 +92,7 @@ func TestRouterDownClearsPool(t *testing.T) {
 	h := host.Host("test.host")
 	r.CollectionsAdded(h, []string{"col1", "col2"})
 	r.Down(h)
-	hosts, err := r.SelectHosts(context.Background(), []string{"col1"})
+	hosts, err := r.SelectHosts(context.Background(), defaultSampleSize, []string{"col1"})
 	require.ErrorIs(t, err, ErrNoHostsAvailable)
 	require.Nil(t, hosts)
 }


### PR DESCRIPTION
This PR un-hardcodes the default sample size parameter/configuration and adds ability to select default sample size in query extensions.

Resolves #75,