### PR TITLE
feat: route queries by the client-signed pool address

### DIFF
--- a/cmd/gateway/commands/start.go
+++ b/cmd/gateway/commands/start.go
@@ -92,7 +92,7 @@ func (a *App) startGateway(cmd *cobra.Command, _ []string) error {
 
 	validators := []endpoint.Validator{endpoint.NewLimitValidator(maxLimit), &endpoint.OrderValidator{}}
 	sampleSize := a.v.GetInt(flagSample)
-	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, sampleSize, logger)
+	handler := endpoint.NewHandler(validators, &endpoint.DefaultCollectionExtractor{}, rtr, collFetcher, sampleSize, logger)
 	endp, err := endpoint.New(a.v.GetString(flagListen), handler, logger)
 	if err != nil {
 		return fmt.Errorf("creating endpoint: %w", err)

--- a/endpoint/errors.go
+++ b/endpoint/errors.go
@@ -56,6 +56,20 @@ var ErrInvalidOrder = errors.New("invalid order")
 // (a fragment spread or inline fragment).
 var ErrUnsupportedSelection = errors.New("unsupported root selection")
 
+// ErrMissingPool is returned when a query carries no signed pool address. Every
+// query must name the pool it bills to.
+var ErrMissingPool = errors.New("query is missing a signed pool address")
+
+// ErrUnknownPool is returned when the signed pool address is not known to the gateway.
+var ErrUnknownPool = errors.New("unknown pool")
+
+// ErrPoolInactive is returned when the signed pool exists but is not active.
+var ErrPoolInactive = errors.New("pool is not active")
+
+// ErrPoolViewMismatch is returned when the query does not target the view the
+// signed pool serves.
+var ErrPoolViewMismatch = errors.New("query does not match the signed pool's view")
+
 // ErrUnexpectedStatus is returned when an upstream host responds with a non-2xx status.
 var ErrUnexpectedStatus = errors.New("unexpected HTTP status")
 

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -20,9 +20,15 @@ import (
 	"github.com/shinzonetwork/shinzo-network-gateway/host"
 )
 
-// HostsSelector interface allows handler to get hosts for given collections.
+// HostsSelector selects the hosts to serve a query from the members of a pool.
 type HostsSelector interface {
-	SelectHosts(ctx context.Context, n int, collections []string) ([]host.Host, error)
+	SelectHosts(ctx context.Context, n int, collections []string, members []host.Host) ([]host.Host, error)
+}
+
+// PoolResolver resolves a signed pool address to the collection its view serves,
+// its member hosts, and whether it is active.
+type PoolResolver interface {
+	ResolvePool(poolAddress string) (host.PoolRoute, bool)
 }
 
 // Handler is a HTTP handler for "POST /graphql" endpoint.
@@ -30,6 +36,7 @@ type Handler struct {
 	validators []Validator
 	extractor  CollectionsExtractor
 	selector   HostsSelector
+	resolver   PoolResolver
 	client     *http.Client
 	logger     *zap.Logger
 
@@ -62,17 +69,18 @@ type hostResponse struct {
 }
 
 // extensions is a copy of Extensions from https://github.com/shinzonetwork/shinzo-querysig/blob/main/billing/
-// The entire dependency tree of shinozo-querysig is to huge to import.
+// The entire dependency tree of shinzo-querysig is too huge to import.
 type extensions struct {
 	RequestSignature string `json:"request_signature"`
 	Nonce            string `json:"nonce"`
 	QueryHash        string `json:"query_hash"`
 	RequestTimestamp uint64 `json:"request_timestamp"`
+	PoolAddress      string `json:"pool_address"`
 	Fanout           int    `json:"fanout"`
 }
 
 // NewHandler creates new Handler instance.
-func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, defaultSampleSize int, logger *zap.Logger) *Handler {
+func NewHandler(validators []Validator, extractor CollectionsExtractor, selector HostsSelector, resolver PoolResolver, defaultSampleSize int, logger *zap.Logger) *Handler {
 	transport := &http.Transport{
 		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		ResponseHeaderTimeout: responseHeaderTimeout,
@@ -82,6 +90,7 @@ func NewHandler(validators []Validator, extractor CollectionsExtractor, selector
 		validators:        validators,
 		extractor:         extractor,
 		selector:          selector,
+		resolver:          resolver,
 		client:            &http.Client{Transport: transport},
 		logger:            logger.Named("handler"),
 		defaultSampleSize: defaultSampleSize,
@@ -140,16 +149,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	n, err := h.getFanout(gqlReq.Extensions)
+	ext, err := parseExtensions(gqlReq.Extensions)
 	if err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid extensions", contentType)
 		return
 	}
-	h.logger.Debug("selecting hosts", zap.Strings("collections", collections), zap.Int("fanout", n))
-	hosts, err := h.selector.SelectHosts(r.Context(), n, collections)
+	n := h.fanout(ext)
+
+	hosts, err := h.selectHosts(r.Context(), n, collections, ext.PoolAddress)
 	if err != nil {
-		h.logger.Warn("failed to select hosts", zap.Strings("collections", collections), zap.Error(err))
-		h.writeError(w, http.StatusServiceUnavailable, err.Error(), contentType)
+		status := http.StatusServiceUnavailable
+		if errors.Is(err, ErrPoolViewMismatch) || errors.Is(err, ErrMissingPool) {
+			status = requestErrorStatus(contentType)
+		}
+		h.logger.Warn("failed to select hosts",
+			zap.Strings("collections", collections), zap.String("pool", ext.PoolAddress), zap.Error(err))
+		h.writeError(w, status, err.Error(), contentType)
 		return
 	}
 
@@ -158,19 +173,52 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.composeResponse(w, responses, contentType)
 }
 
-func (h *Handler) getFanout(ext json.RawMessage) (int, error) {
-	fanout := h.defaultSampleSize
-	if ext != nil {
-		var deserialized extensions
-		err := json.Unmarshal(ext, &deserialized)
-		if err != nil {
-			return 0, err
-		}
-		if deserialized.Fanout > 0 {
-			fanout = deserialized.Fanout
-		}
+// parseExtensions decodes the signed extensions envelope. A nil raw message
+// (request carried no extensions) yields the zero value, whose empty pool
+// address selectHosts then rejects as a missing signed pool.
+func parseExtensions(raw json.RawMessage) (extensions, error) {
+	var ext extensions
+	if raw == nil {
+		return ext, nil
 	}
-	return fanout, nil
+	if err := json.Unmarshal(raw, &ext); err != nil {
+		return extensions{}, err
+	}
+	return ext, nil
+}
+
+// fanout is the requested sample size: the client's fanout when set, else the default.
+func (h *Handler) fanout(ext extensions) int {
+	if ext.Fanout > 0 {
+		return ext.Fanout
+	}
+	return h.defaultSampleSize
+}
+
+// selectHosts resolves the query's signed pool and returns the hosts to fan out
+// to. The pool must be active and its view must be the collection the query
+// targets; the fan-out is then restricted to the pool's members. A query with no
+// signed pool address is rejected, since every query must name the pool it bills
+// to.
+func (h *Handler) selectHosts(ctx context.Context, n int, collections []string, poolAddress string) ([]host.Host, error) {
+	if poolAddress == "" {
+		return nil, ErrMissingPool
+	}
+
+	route, ok := h.resolver.ResolvePool(poolAddress)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownPool, poolAddress)
+	}
+	if !route.IsActive {
+		return nil, fmt.Errorf("%w: %s", ErrPoolInactive, poolAddress)
+	}
+	if len(collections) != 1 || collections[0] != route.Collection {
+		return nil, fmt.Errorf("%w: pool %s serves %q", ErrPoolViewMismatch, poolAddress, route.Collection)
+	}
+
+	h.logger.Debug("selecting hosts in pool",
+		zap.String("pool", poolAddress), zap.String("collection", route.Collection), zap.Int("fanout", n))
+	return h.selector.SelectHosts(ctx, n, collections, route.Members)
 }
 
 func (h *Handler) getHostsResponses(ctx context.Context, hosts []host.Host, body []byte, hostHeader, authHeader string) []hostResponse {

--- a/endpoint/handler_test.go
+++ b/endpoint/handler_test.go
@@ -39,9 +39,18 @@ type mockSelector struct {
 	mock.Mock
 }
 
-func (m *mockSelector) SelectHosts(ctx context.Context, n int, collections []string) ([]host.Host, error) {
-	args := m.Called(ctx, n, collections)
+func (m *mockSelector) SelectHosts(ctx context.Context, n int, collections []string, members []host.Host) ([]host.Host, error) {
+	args := m.Called(ctx, n, collections, members)
 	return args.Get(0).([]host.Host), args.Error(1)
+}
+
+type mockResolver struct {
+	mock.Mock
+}
+
+func (m *mockResolver) ResolvePool(poolAddress string) (host.PoolRoute, bool) {
+	args := m.Called(poolAddress)
+	return args.Get(0).(host.PoolRoute), args.Bool(1)
 }
 
 type failValidator struct{}
@@ -190,7 +199,7 @@ func TestHandlerGetHostsResponses(t *testing.T) {
 			th := setupTestHosts(c.kinds)
 			defer th.cleanup()
 
-			h := NewHandler(nil, nil, nil, defaultSampleSize, logger)
+			h := NewHandler(nil, nil, nil, nil, defaultSampleSize, logger)
 			require.NotNil(t, h)
 
 			timeout := c.timeout
@@ -238,6 +247,7 @@ func TestHandler(t *testing.T) {
 		validators     []Validator
 		setupExtractor func(*mockExtractor)
 		setupSelector  func(*mockSelector, []host.Host)
+		setupResolver  func(*mockResolver, []host.Host)
 		wantStatus     int
 		wantBodyHas    string
 	}{
@@ -290,24 +300,30 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			name: "selector error",
-			body: `{"query":"{ hero { name } }"}`,
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
-			setupSelector: func(sel *mockSelector, _ []host.Host) {
-				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return([]host.Host(nil), errNoHosts)
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return([]host.Host(nil), errNoHosts)
 			},
 			wantStatus:  http.StatusServiceUnavailable,
 			wantBodyHas: "no hosts",
 		},
 		{
 			name: "successful query",
-			body: `{"query":"{ hero { name } }"}`,
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -342,13 +358,16 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			name:       "limit ok",
-			body:       `{"query":"{ hero(limit: 100) { name } }"}`,
+			body:       `{"query":"{ hero(limit: 100) { name } }","extensions":{"pool_address":"0xpool"}}`,
 			validators: []Validator{NewLimitValidator(100)},
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero(limit: 100) { name } }")).Return([]string{"hero"}, nil)
 			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -362,37 +381,46 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			name:       "limit ok, order ok",
-			body:       `{"query":"{ hero(limit: 10, order: {name: ASC}) { name } }"}`,
+			body:       `{"query":"{ hero(limit: 10, order: {name: ASC}) { name } }","extensions":{"pool_address":"0xpool"}}`,
 			validators: []Validator{NewLimitValidator(100), &OrderValidator{}},
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mock.Anything).Return([]string{"hero"}, nil)
 			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
 		},
 		{
 			name: "fanout from extensions overrides default sample size",
-			body: `{"query":"{ hero { name } }","extensions":{"fanout":5}}`,
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool","fanout":5}}`,
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, 5, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, 5, []string{"hero"}, hosts).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
 		},
 		{
 			name: "zero fanout in extensions falls back to default sample size",
-			body: `{"query":"{ hero { name } }","extensions":{"fanout":0}}`,
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool","fanout":0}}`,
 			setupExtractor: func(ext *mockExtractor) {
 				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
 			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
 			setupSelector: func(sel *mockSelector, hosts []host.Host) {
-				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}).Return(hosts, nil)
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return(hosts, nil)
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
@@ -405,6 +433,66 @@ func TestHandler(t *testing.T) {
 			},
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "invalid extensions",
+		},
+		{
+			name: "query without a signed pool is rejected",
+			body: `{"query":"{ hero { name } }"}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: ErrMissingPool.Error(),
+		},
+		{
+			name: "signed pool routes to pool members",
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: true}, true)
+			},
+			setupSelector: func(sel *mockSelector, hosts []host.Host) {
+				sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{"hero"}, hosts).Return(hosts, nil)
+			},
+			wantStatus:  http.StatusOK,
+			wantBodyHas: `{"data":{"hero":{"name":"Luke"}},"extensions":{"consensus":"full"}}`,
+		},
+		{
+			name: "unknown signed pool is unavailable",
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupResolver: func(rslv *mockResolver, _ []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{}, false)
+			},
+			wantStatus:  http.StatusServiceUnavailable,
+			wantBodyHas: ErrUnknownPool.Error(),
+		},
+		{
+			name: "inactive signed pool is unavailable",
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "hero", Members: hosts, IsActive: false}, true)
+			},
+			wantStatus:  http.StatusServiceUnavailable,
+			wantBodyHas: ErrPoolInactive.Error(),
+		},
+		{
+			name: "signed pool serving another view is a bad request",
+			body: `{"query":"{ hero { name } }","extensions":{"pool_address":"0xpool"}}`,
+			setupExtractor: func(ext *mockExtractor) {
+				ext.On("ExtractCollections", mustParseQuery(t, "{ hero { name } }")).Return([]string{"hero"}, nil)
+			},
+			setupResolver: func(rslv *mockResolver, hosts []host.Host) {
+				rslv.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: "villain", Members: hosts, IsActive: true}, true)
+			},
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: ErrPoolViewMismatch.Error(),
 		},
 	}
 
@@ -419,14 +507,18 @@ func TestHandler(t *testing.T) {
 			defer okHost.Close()
 			ext := &mockExtractor{}
 			sel := &mockSelector{}
+			res := &mockResolver{}
 			if c.setupExtractor != nil {
 				c.setupExtractor(ext)
 			}
 			if c.setupSelector != nil {
 				c.setupSelector(sel, []host.Host{host.Host(okHost.URL)})
 			}
+			if c.setupResolver != nil {
+				c.setupResolver(res, []host.Host{host.Host(okHost.URL)})
+			}
 
-			h := NewHandler(c.validators, ext, sel, defaultSampleSize, logger)
+			h := NewHandler(c.validators, ext, sel, res, defaultSampleSize, logger)
 
 			accept := c.accept
 			if accept == "" {
@@ -454,6 +546,7 @@ func TestHandler(t *testing.T) {
 
 			ext.AssertExpectations(t)
 			sel.AssertExpectations(t)
+			res.AssertExpectations(t)
 		})
 	}
 }
@@ -693,7 +786,7 @@ func TestComposeResponse(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := NewHandler(nil, nil, nil, defaultSampleSize, logger)
+			h := NewHandler(nil, nil, nil, nil, defaultSampleSize, logger)
 			w := httptest.NewRecorder()
 
 			h.composeResponse(w, c.responses, c.contentType)
@@ -818,16 +911,21 @@ func TestHandlerForwardsHostAndAuth(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	hosts := []host.Host{host.Host(srv.URL)}
+
 	ext := &mockExtractor{}
 	ext.On("ExtractCollections", mock.Anything).Return([]string{collection}, nil)
 
+	res := &mockResolver{}
+	res.On("ResolvePool", "0xpool").Return(host.PoolRoute{Collection: collection, Members: hosts, IsActive: true}, true)
+
 	sel := &mockSelector{}
-	sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{collection}).Return([]host.Host{host.Host(srv.URL)}, nil)
+	sel.On("SelectHosts", mock.Anything, defaultSampleSize, []string{collection}, hosts).Return(hosts, nil)
 
 	logger, _ := zap.NewDevelopment()
-	h := NewHandler(nil, ext, sel, defaultSampleSize, logger)
+	h := NewHandler(nil, ext, sel, res, defaultSampleSize, logger)
 
-	req := httptest.NewRequest(http.MethodPost, "http://"+originalHost+"/graphql", strings.NewReader(`{"query":"{ TestView { id } }"}`))
+	req := httptest.NewRequest(http.MethodPost, "http://"+originalHost+"/graphql", strings.NewReader(`{"query":"{ TestView { id } }","extensions":{"pool_address":"0xpool"}}`))
 	req.Host = originalHost
 	req.Header.Set("Content-Type", contentTypeJSON)
 	req.Header.Set("Accept", contentTypeGraphQLResponse)

--- a/host/pool_route.go
+++ b/host/pool_route.go
@@ -1,0 +1,11 @@
+package host
+
+// PoolRoute is the routing information the gateway keeps for one on-chain pool:
+// the collection its view serves, the member hosts (by endpoint), and whether the
+// pool is currently active. It lets the gateway fan a query out to exactly the
+// hosts in the pool the client signed, instead of every host serving the view.
+type PoolRoute struct {
+	Collection string
+	Members    []Host
+	IsActive   bool
+}

--- a/host/shinzohub_collections_fetcher.go
+++ b/host/shinzohub_collections_fetcher.go
@@ -3,6 +3,7 @@ package host
 import (
 	"context"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +23,9 @@ type ShinzohubCollectionsFetcher struct {
 	mtx         sync.Mutex
 	collections map[Host][]string
 
+	poolMtx    sync.RWMutex
+	poolRoutes map[string]PoolRoute
+
 	logger *zap.Logger
 }
 
@@ -37,6 +41,7 @@ func NewShinzohubCollectionsFetcher(baseURL string, refreshInterval time.Duratio
 		client:          c,
 		refreshInterval: refreshInterval,
 		collections:     make(map[Host][]string),
+		poolRoutes:      make(map[string]PoolRoute),
 		logger:          logger.Named("shinzohub-collections-fetcher"),
 	}, nil
 }
@@ -95,6 +100,7 @@ func (f *ShinzohubCollectionsFetcher) refresh(ctx context.Context) (map[Host][]s
 	}
 
 	collsByHost := make(map[Host][]string)
+	poolRoutes := make(map[string]PoolRoute, len(pools))
 	for _, p := range pools {
 		coll, ok := collsByView[p.Pool.ViewAddress]
 		if !ok {
@@ -102,6 +108,7 @@ func (f *ShinzohubCollectionsFetcher) refresh(ctx context.Context) (map[Host][]s
 				zap.String("pool", p.Pool.PoolAddress), zap.String("view", p.Pool.ViewAddress))
 			continue
 		}
+		members := make([]Host, 0, len(p.Hosts))
 		for _, h := range p.Hosts {
 			endpoint, ok := endpointByAddress[h.HostAddress]
 			if !ok {
@@ -110,8 +117,17 @@ func (f *ShinzohubCollectionsFetcher) refresh(ctx context.Context) (map[Host][]s
 				continue
 			}
 			collsByHost[endpoint] = append(collsByHost[endpoint], coll)
+			members = append(members, endpoint)
+		}
+		// Key by lowercase address so a checksummed pool_address from the client
+		// resolves regardless of the case shinzohub stores.
+		poolRoutes[strings.ToLower(p.Pool.PoolAddress)] = PoolRoute{
+			Collection: coll,
+			Members:    members,
+			IsActive:   p.IsActive,
 		}
 	}
+	f.setPoolRoutes(poolRoutes)
 
 	// dedup in case same view is served by many pools
 	for h, colls := range collsByHost {
@@ -123,4 +139,20 @@ func (f *ShinzohubCollectionsFetcher) refresh(ctx context.Context) (map[Host][]s
 		zap.Int("views", len(views)), zap.Int("hosts", len(hosts)), zap.Int("pools", len(pools)),
 		zap.Int("hostsWithCollections", len(collsByHost)))
 	return collsByHost, nil
+}
+
+func (f *ShinzohubCollectionsFetcher) setPoolRoutes(routes map[string]PoolRoute) {
+	f.poolMtx.Lock()
+	defer f.poolMtx.Unlock()
+	f.poolRoutes = routes
+}
+
+// ResolvePool returns the routing information for a pool by its address. The
+// lookup is case-insensitive. ok is false if no pool with that address was seen
+// in the last refresh.
+func (f *ShinzohubCollectionsFetcher) ResolvePool(poolAddress string) (PoolRoute, bool) {
+	f.poolMtx.RLock()
+	defer f.poolMtx.RUnlock()
+	r, ok := f.poolRoutes[strings.ToLower(poolAddress)]
+	return r, ok
 }

--- a/host/shinzohub_collections_fetcher_test.go
+++ b/host/shinzohub_collections_fetcher_test.go
@@ -91,6 +91,82 @@ func TestShinzohubCollectionsFetcher(t *testing.T) {
 	require.Empty(t, colls)
 }
 
+func TestShinzohubCollectionsFetcherResolvePool(t *testing.T) {
+	t.Parallel()
+
+	const viewsJSON = `{
+		"views": [
+			{"name": "block_view", "creator": "c1", "address": "0xVIEW_BLOCK", "height": "1", "metadata": {"root_type": "Block"}}
+		],
+		"pagination": {"next_key": null, "total": "1"}
+	}`
+	const hostsJSON = `{
+		"hosts": [
+			{"address": "shinzo1hosta", "did": "did:key:x", "connection_string": "1.2.3.4:8080", "endpoint_address": "http://host-a.example/graphql"}
+		],
+		"pagination": {"next_key": null, "total": "1"}
+	}`
+	const detailsJSON = `{
+		"details": [
+			{
+				"pool": {"pool_address": "0xPOOLACTIVE", "view_address": "0xVIEW_BLOCK", "config": {"window_size": "10000"}, "created_at": "1"},
+				"hosts": [{"pool_address": "0xPOOLACTIVE", "host_address": "shinzo1hosta", "host": {"joined_at": "1"}}],
+				"demands": [], "stats": {}, "is_active": true
+			},
+			{
+				"pool": {"pool_address": "0xPOOLINACTIVE", "view_address": "0xVIEW_BLOCK", "config": {"window_size": "50000"}, "created_at": "1"},
+				"hosts": [{"pool_address": "0xPOOLINACTIVE", "host_address": "shinzo1hosta", "host": {"joined_at": "1"}}],
+				"demands": [], "stats": {}, "is_active": false
+			}
+		],
+		"pagination": {"next_key": null, "total": "2"}
+	}`
+
+	srv := newTestServer(t, map[string]string{
+		"/shinzonetwork/view/v1/views":      viewsJSON,
+		"/shinzonetwork/view/v1/views?meta": viewsJSON,
+		"/shinzonetwork/host/v1/hosts":      hostsJSON,
+		"/shinzonetwork/host/v1/details":    detailsJSON,
+	})
+	defer srv.Close()
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	f, err := NewShinzohubCollectionsFetcher(srv.URL, time.Minute, logger)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// no pool routes until the first fetch triggers a refresh
+	_, ok := f.ResolvePool("0xPOOLACTIVE")
+	require.False(t, ok)
+
+	_, err = f.FetchCollections(ctx, Host("http://host-a.example/graphql"))
+	require.NoError(t, err)
+
+	const endpoint = Host("http://host-a.example/graphql")
+
+	route, ok := f.ResolvePool("0xPOOLACTIVE")
+	require.True(t, ok)
+	require.Equal(t, PoolRoute{Collection: "Block", Members: []Host{endpoint}, IsActive: true}, route)
+
+	// lookup is case-insensitive
+	lower, ok := f.ResolvePool("0xpoolactive")
+	require.True(t, ok)
+	require.Equal(t, route, lower)
+
+	// an inactive pool is still resolved, but flagged inactive so the gateway can reject it
+	inactive, ok := f.ResolvePool("0xPOOLINACTIVE")
+	require.True(t, ok)
+	require.Equal(t, "Block", inactive.Collection)
+	require.False(t, inactive.IsActive)
+
+	// unknown pool is not found
+	_, ok = f.ResolvePool("0xUNKNOWN")
+	require.False(t, ok)
+}
+
 func newTestServer(t *testing.T, routes map[string]string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/router/router.go
+++ b/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"errors"
+	"math/rand/v2"
 	"sync"
 
 	"github.com/shinzonetwork/shinzo-network-gateway/endpoint"
@@ -15,6 +16,9 @@ var (
 	ErrPoolNotSupported = errors.New("queries spanning multiple collections are not supported")
 	// ErrPoolNotFound is returned when pool was not found by the Router.
 	ErrPoolNotFound = errors.New("no hosts serve the requested collection")
+	// ErrNoLivePoolMembers is returned when live hosts serve the requested
+	// collection but none of them are members of the requested pool.
+	ErrNoLivePoolMembers = errors.New("no live hosts in the requested pool")
 )
 
 // Router selects the hosts for query based on information from Registry.
@@ -40,8 +44,14 @@ func New(logger *zap.Logger) *Router {
 	return r
 }
 
-// SelectHosts finds the hosts that serve all the collections, and return random sample.
-func (r *Router) SelectHosts(_ context.Context, n int, collections []string) ([]host.Host, error) {
+// SelectHosts returns a random sample of up to n hosts that serve the collection,
+// are currently live, and are members of the given pool. It intersects the live
+// hosts for the collection with the pool's member set, so a query reaches only
+// hosts in the window the client signed. Only single-collection queries are
+// supported. Returns ErrPoolNotSupported if collections is not exactly one,
+// ErrPoolNotFound if no live hosts serve the collection, or ErrNoLivePoolMembers
+// if some do but none belong to the pool.
+func (r *Router) SelectHosts(_ context.Context, n int, collections []string, members []host.Host) ([]host.Host, error) {
 	if len(collections) != 1 {
 		return nil, ErrPoolNotSupported
 	}
@@ -49,15 +59,33 @@ func (r *Router) SelectHosts(_ context.Context, n int, collections []string) ([]
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
-	col := collections[0]
-	pool, ok := r.pools[col]
+	p, ok := r.pools[collections[0]]
 	if !ok {
 		return nil, ErrPoolNotFound
 	}
 
-	// return requested number of hosts, or all of them
-	l := min(n, len(pool.hosts.Pool()))
-	return pool.get(l)
+	memberSet := make(map[host.Host]struct{}, len(members))
+	for _, m := range members {
+		memberSet[m] = struct{}{}
+	}
+
+	live := p.hosts.Pool()
+	candidates := make([]host.Host, 0, len(live))
+	for _, h := range live {
+		if _, ok := memberSet[h]; ok {
+			candidates = append(candidates, h)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, ErrNoLivePoolMembers
+	}
+
+	// ChaCha8 seeded from crypto/rand is a cryptographically strong shuffle source.
+	rng := rand.New(rand.NewChaCha8(mustGetSeed())) // nolint:gosec
+	rng.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+	return candidates[:min(n, len(candidates))], nil
 }
 
 // Up implements host.Observer; the Router does not track hosts until they advertise collections.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -21,43 +21,68 @@ func TestSelectHosts(t *testing.T) {
 		"host2.test": {"col1", "col2"},
 		"host3.test": {"col1", "col2", "col3"},
 	}
+	// allMembers covers every host, so a query is bounded only by the collection.
+	allMembers := []host.Host{"host1.test", "host2.test", "host3.test"}
 
-	// those test cases are mostly about testing router-related logic
-	// actuall pool selection is not teste
 	cases := []struct {
 		name     string
 		colls    []string
+		members  []host.Host
 		expected []host.Host
 		err      error
 	}{
 		{
-			name:     "all hosts",
+			name:     "all hosts serving the collection are pool members",
 			colls:    []string{"col1"},
+			members:  allMembers,
 			expected: []host.Host{"host1.test", "host2.test", "host3.test"},
 		},
 		{
 			name:     "single host",
 			colls:    []string{"col3"},
+			members:  allMembers,
 			expected: []host.Host{"host3.test"},
 		},
 		{
-			name:  "pool not found",
-			colls: []string{"col123"},
-			err:   ErrPoolNotFound,
+			name:     "restricted to pool members",
+			colls:    []string{"col1"},
+			members:  []host.Host{"host1.test", "host2.test"},
+			expected: []host.Host{"host1.test", "host2.test"},
 		},
 		{
-			name:  "unsupported pool (2 collections)",
-			colls: []string{"col1", "col2"},
-			err:   ErrPoolNotSupported,
+			name:     "member not serving the collection is excluded",
+			colls:    []string{"col2"},
+			members:  []host.Host{"host1.test", "host2.test"}, // host1 serves only col1
+			expected: []host.Host{"host2.test"},
 		},
 		{
-			name:  "unsupported pool (0 collections)",
-			colls: []string{},
-			err:   ErrPoolNotSupported,
+			name:    "pool not found",
+			colls:   []string{"col123"},
+			members: allMembers,
+			err:     ErrPoolNotFound,
 		},
 		{
-			name: "unsupported pool (`nil` collections)",
-			err:  ErrPoolNotSupported,
+			name:    "no live pool members",
+			colls:   []string{"col1"},
+			members: []host.Host{"other.test"},
+			err:     ErrNoLivePoolMembers,
+		},
+		{
+			name:    "unsupported pool (2 collections)",
+			colls:   []string{"col1", "col2"},
+			members: allMembers,
+			err:     ErrPoolNotSupported,
+		},
+		{
+			name:    "unsupported pool (0 collections)",
+			colls:   []string{},
+			members: allMembers,
+			err:     ErrPoolNotSupported,
+		},
+		{
+			name:    "unsupported pool (`nil` collections)",
+			members: allMembers,
+			err:     ErrPoolNotSupported,
 		},
 	}
 
@@ -73,7 +98,7 @@ func TestSelectHosts(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
-			actual, err := r.SelectHosts(ctx, defaultSampleSize, c.colls)
+			actual, err := r.SelectHosts(ctx, defaultSampleSize, c.colls, c.members)
 			if c.err != nil {
 				require.ErrorIs(t, err, c.err)
 				require.Nil(t, actual)
@@ -85,15 +110,57 @@ func TestSelectHosts(t *testing.T) {
 	}
 }
 
+// TestSelectHostsSamplesRandomly checks the fan-out is a random sample of the
+// members rather than the same hosts every call: with n smaller than the
+// membership, each call returns exactly n in-pool hosts and every member is
+// eventually selected across many calls.
+func TestSelectHostsSamplesRandomly(t *testing.T) {
+	t.Parallel()
+	logger, _ := zap.NewDevelopment()
+	r := New(logger)
+	members := []host.Host{"h1", "h2", "h3", "h4", "h5", "h6"}
+	for _, h := range members {
+		r.CollectionsAdded(h, []string{"col1"})
+	}
+
+	seen := map[host.Host]bool{}
+	for range 200 {
+		got, err := r.SelectHosts(context.Background(), 2, []string{"col1"}, members)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		for _, h := range got {
+			require.Contains(t, members, h)
+			seen[h] = true
+		}
+	}
+	require.Len(t, seen, len(members), "every member should be selected across many calls; sampling is not random")
+}
+
+// TestRouterDownClearsPool checks that a pool member that has gone offline is
+// dropped from the pool and therefore not selected.
 func TestRouterDownClearsPool(t *testing.T) {
 	t.Parallel()
 	logger, _ := zap.NewDevelopment()
 	r := New(logger)
-	h := host.Host("test.host")
-	r.CollectionsAdded(h, []string{"col1", "col2"})
-	r.Down(h)
-	hosts, err := r.SelectHosts(context.Background(), defaultSampleSize, []string{"col1"})
-	require.ErrorIs(t, err, ErrNoHostsAvailable)
+	r.CollectionsAdded("host1.test", []string{"col1", "col2"})
+	r.CollectionsAdded("host2.test", []string{"col1"})
+	members := []host.Host{"host1.test", "host2.test"}
+
+	// with both members live, both can be selected
+	hosts, err := r.SelectHosts(context.Background(), defaultSampleSize, []string{"col1"}, members)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []host.Host{"host1.test", "host2.test"}, hosts)
+
+	// once host1 goes offline it must not be selected
+	r.Down("host1.test")
+	hosts, err = r.SelectHosts(context.Background(), defaultSampleSize, []string{"col1"}, members)
+	require.NoError(t, err)
+	require.Equal(t, []host.Host{"host2.test"}, hosts)
+
+	// once every member is offline, there are no live members
+	r.Down("host2.test")
+	hosts, err = r.SelectHosts(context.Background(), defaultSampleSize, []string{"col1"}, members)
+	require.ErrorIs(t, err, ErrNoLivePoolMembers)
 	require.Nil(t, hosts)
 }
 


### PR DESCRIPTION
Routes each query by the client-signed pool_address: resolves the pool to its member hosts via shinzohub, verifies the pool is active and serves the queried view, then fans out only to those live members. A query with no signed pool is rejected, and host selection is consolidated into a single pool-scoped SelectHosts.